### PR TITLE
Backend/feature/get all trips

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -60,6 +60,12 @@
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo.spring3x</artifactId>
+            <version>4.15.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/org/example/backend/controller/TripController.java
+++ b/backend/src/main/java/org/example/backend/controller/TripController.java
@@ -1,0 +1,23 @@
+package org.example.backend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.model.Trip;
+import org.example.backend.service.TripService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/trips")
+@RequiredArgsConstructor
+public class TripController {
+
+    private final TripService tripService;
+
+    @GetMapping
+    public List<Trip> getAllTrips(){
+        return tripService.findAllTrips();
+    }
+}

--- a/backend/src/main/java/org/example/backend/model/Destination.java
+++ b/backend/src/main/java/org/example/backend/model/Destination.java
@@ -1,0 +1,12 @@
+package org.example.backend.model;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+public record Destination(
+        String country,
+        String city,
+        String region,
+        ZonedDateTime date
+) {
+}

--- a/backend/src/main/java/org/example/backend/model/Trip.java
+++ b/backend/src/main/java/org/example/backend/model/Trip.java
@@ -1,0 +1,13 @@
+package org.example.backend.model;
+
+import org.springframework.data.mongodb.core.mapping.MongoId;
+
+public record Trip(
+        @MongoId
+        String id,
+        String title,
+        String description,
+        String reason,
+        Destination[] destinations
+) {
+}

--- a/backend/src/main/java/org/example/backend/model/Trip.java
+++ b/backend/src/main/java/org/example/backend/model/Trip.java
@@ -2,12 +2,14 @@ package org.example.backend.model;
 
 import org.springframework.data.mongodb.core.mapping.MongoId;
 
+import java.util.List;
+
 public record Trip(
         @MongoId
         String id,
         String title,
         String description,
         String reason,
-        Destination[] destinations
+        List<Destination> destinations
 ) {
 }

--- a/backend/src/main/java/org/example/backend/repo/TripRepo.java
+++ b/backend/src/main/java/org/example/backend/repo/TripRepo.java
@@ -1,0 +1,7 @@
+package org.example.backend.repo;
+
+import org.example.backend.model.Trip;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface TripRepo extends MongoRepository<Trip, String> {
+}

--- a/backend/src/main/java/org/example/backend/service/TripService.java
+++ b/backend/src/main/java/org/example/backend/service/TripService.java
@@ -1,0 +1,19 @@
+package org.example.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.model.Trip;
+import org.example.backend.repo.TripRepo;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TripService {
+
+    private final TripRepo tripRepo;
+
+    public List<Trip> findAllTrips() {
+        return tripRepo.findAll();
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=backend
+spring.data.mongodb.uri=${MONGO_DB_URI}

--- a/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
@@ -1,0 +1,27 @@
+package org.example.backend.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class TripControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    void getAllTrips() throws Exception {
+        mvc.perform(MockMvcRequestBuilders
+                .get( "/api/trips"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("[]"));
+    }
+}

--- a/backend/src/test/java/org/example/backend/service/TripServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/TripServiceTest.java
@@ -24,8 +24,8 @@ class TripServiceTest {
         Destination destination1 = new Destination("Germany", "Berlin", "Berlin", ZonedDateTime.now());
         Destination destination2 = new Destination("France", "Paris", "Île-de-France", ZonedDateTime.now());
 
-        Trip trip1 = new Trip("1", "Business Trip", "Meeting with clients", "Business", new Destination[]{destination1});
-        Trip trip2 = new Trip("2", "Vacation", "Family vacation", "Leisure", new Destination[]{destination2});
+        Trip trip1 = new Trip("1", "Business Trip", "Meeting with clients", "Business", List.of(new Destination[]{destination1}));
+        Trip trip2 = new Trip("2", "Vacation", "Family vacation", "Leisure", List.of(new Destination[]{destination2}));
 
         List<Trip> listTrips = List.of(trip1, trip2);
 

--- a/backend/src/test/java/org/example/backend/service/TripServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/TripServiceTest.java
@@ -1,0 +1,40 @@
+package org.example.backend.service;
+
+import org.example.backend.model.Destination;
+import org.example.backend.model.Trip;
+import org.example.backend.repo.TripRepo;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class TripServiceTest {
+
+    private final TripRepo tripRepoMock = mock(TripRepo.class);
+    private final TripService tripService = new TripService(tripRepoMock);
+
+
+    @Test
+    @DirtiesContext
+    void findAllTrips() {
+        Destination destination1 = new Destination("Germany", "Berlin", "Berlin", ZonedDateTime.now());
+        Destination destination2 = new Destination("France", "Paris", "Île-de-France", ZonedDateTime.now());
+
+        Trip trip1 = new Trip("1", "Business Trip", "Meeting with clients", "Business", new Destination[]{destination1});
+        Trip trip2 = new Trip("2", "Vacation", "Family vacation", "Leisure", new Destination[]{destination2});
+
+        List<Trip> listTrips = List.of(trip1, trip2);
+
+        when(tripRepoMock.findAll()).thenReturn(listTrips);
+
+        List<Trip> result = tripService.findAllTrips();
+
+        verify(tripRepoMock).findAll();
+
+        assertEquals(listTrips, result);
+    }
+}

--- a/backend/src/test/java/org/example/backend/service/TripServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/TripServiceTest.java
@@ -24,8 +24,8 @@ class TripServiceTest {
         Destination destination1 = new Destination("Germany", "Berlin", "Berlin", ZonedDateTime.now());
         Destination destination2 = new Destination("France", "Paris", "Île-de-France", ZonedDateTime.now());
 
-        Trip trip1 = new Trip("1", "Business Trip", "Meeting with clients", "Business", List.of(new Destination[]{destination1}));
-        Trip trip2 = new Trip("2", "Vacation", "Family vacation", "Leisure", List.of(new Destination[]{destination2}));
+        Trip trip1 = new Trip("1", "Business Trip", "Meeting with clients", "Business", List.of(destination1));
+        Trip trip2 = new Trip("2", "Vacation", "Family vacation", "Leisure", List.of(destination2));
 
         List<Trip> listTrips = List.of(trip1, trip2);
 

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+de.flapdoodle.mongodb.embedded.version=7.0.4


### PR DESCRIPTION
This PR introduces a new GET endpoint /api/trips that allows for retrieving all Trips records. The implementation includes both the service and controller layers necessary to support this functionality. Additionally, unit and integration tests have been added to ensure the endpoint behaves as expected.