### PR TITLE
Backend/feature/post trip

### DIFF
--- a/backend/src/main/java/org/example/backend/controller/TripController.java
+++ b/backend/src/main/java/org/example/backend/controller/TripController.java
@@ -2,10 +2,9 @@ package org.example.backend.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.model.Trip;
+import org.example.backend.model.TripDto;
 import org.example.backend.service.TripService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -19,5 +18,10 @@ public class TripController {
     @GetMapping
     public List<Trip> getAllTrips(){
         return tripService.findAllTrips();
+    }
+
+    @PostMapping
+    public Trip postTrip(@RequestBody TripDto newTripEntries){
+        return tripService.addTrip(newTripEntries);
     }
 }

--- a/backend/src/main/java/org/example/backend/model/Destination.java
+++ b/backend/src/main/java/org/example/backend/model/Destination.java
@@ -1,12 +1,11 @@
 package org.example.backend.model;
 
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 
 public record Destination(
         String country,
         String city,
         String region,
-        ZonedDateTime date
+        LocalDateTime date
 ) {
 }

--- a/backend/src/main/java/org/example/backend/model/TripDto.java
+++ b/backend/src/main/java/org/example/backend/model/TripDto.java
@@ -1,0 +1,11 @@
+package org.example.backend.model;
+
+import java.util.List;
+
+public record TripDto(
+        String title,
+        String description,
+        String reason,
+        List<Destination> destinations
+) {
+}

--- a/backend/src/main/java/org/example/backend/service/TripService.java
+++ b/backend/src/main/java/org/example/backend/service/TripService.java
@@ -2,6 +2,7 @@ package org.example.backend.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.model.Trip;
+import org.example.backend.model.TripDto;
 import org.example.backend.repo.TripRepo;
 import org.springframework.stereotype.Service;
 
@@ -15,5 +16,17 @@ public class TripService {
 
     public List<Trip> findAllTrips() {
         return tripRepo.findAll();
+    }
+
+    public Trip addTrip(TripDto newTripEntries) {
+        Trip newTrip = new Trip(
+                null,
+                newTripEntries.title(),
+                newTripEntries.description(),
+                newTripEntries.reason(),
+                newTripEntries.destinations()
+        );
+
+          return tripRepo.save(newTrip);
     }
 }

--- a/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
@@ -4,11 +4,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -23,5 +24,58 @@ class TripControllerTest {
                 .get( "/api/trips"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("[]"));
+    }
+
+    @Test
+    void postTrip() throws Exception {
+        mvc.perform(MockMvcRequestBuilders
+                .post("/api/trips")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+ {
+                                    "title": "Business Trip",
+                                    "description": "Meeting with clients",
+                                    "reason": "Business",
+                                    "destinations": [
+                                        {
+                                            "country": "Germany",
+                                            "city": "Berlin",
+                                            "region": "Berlin",
+                                            "date": "2024-05-20T00:00:00"
+                                        },
+                                        {
+                                            "country": "France",
+                                            "city": "Paris",
+                                            "region": "Île-de-France",
+                                            "date": "2024-05-25T00:00:00"
+                                        }
+                                    ]
+                                }
+"""
+                ))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+{
+                                    "title": "Business Trip",
+                                    "description": "Meeting with clients",
+                                    "reason": "Business",
+                                    "destinations": [
+                                         {
+                                            "country": "Germany",
+                                            "city": "Berlin",
+                                            "region": "Berlin",
+                                            "date": "2024-05-20T00:00:00"
+                                        },
+                                        {
+                                            "country": "France",
+                                            "city": "Paris",
+                                            "region": "Île-de-France",
+                                            "date": "2024-05-25T00:00:00"
+                                        }
+                                    ]
+                                }
+"""
+                ))
+                .andExpect(jsonPath("$.id").exists());
     }
 }

--- a/backend/src/test/java/org/example/backend/service/TripServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/TripServiceTest.java
@@ -2,11 +2,12 @@ package org.example.backend.service;
 
 import org.example.backend.model.Destination;
 import org.example.backend.model.Trip;
+import org.example.backend.model.TripDto;
 import org.example.backend.repo.TripRepo;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.annotation.DirtiesContext;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,8 +22,8 @@ class TripServiceTest {
     @Test
     @DirtiesContext
     void findAllTrips() {
-        Destination destination1 = new Destination("Germany", "Berlin", "Berlin", ZonedDateTime.now());
-        Destination destination2 = new Destination("France", "Paris", "Île-de-France", ZonedDateTime.now());
+        Destination destination1 = new Destination("Germany", "Berlin", "Berlin", LocalDateTime.now());
+        Destination destination2 = new Destination("France", "Paris", "Île-de-France", LocalDateTime.now());
 
         Trip trip1 = new Trip("1", "Business Trip", "Meeting with clients", "Business", List.of(destination1));
         Trip trip2 = new Trip("2", "Vacation", "Family vacation", "Leisure", List.of(destination2));
@@ -36,5 +37,27 @@ class TripServiceTest {
         verify(tripRepoMock).findAll();
 
         assertEquals(listTrips, result);
+    }
+
+    @Test
+    @DirtiesContext
+    void addTrip() {
+        Destination destination1 = new Destination("Germany", "Berlin", "Berlin", LocalDateTime.now());
+        Destination destination2 = new Destination("France", "Paris", "Île-de-France", LocalDateTime.now());
+
+        List<Destination> listDestinations = List.of(destination1, destination2);
+
+        Trip trip1 = new Trip(null, "Business Trip", "Meeting with clients", "Business", listDestinations);
+        TripDto trip1Dto = new TripDto( "Business Trip", "Meeting with clients", "Business", listDestinations);
+
+        when(tripRepoMock.save(trip1)).thenReturn(trip1);
+
+        Trip result = tripService.addTrip(trip1Dto);
+
+        verify(tripRepoMock).save(trip1);
+
+        assertEquals(trip1, result);
+
+
     }
 }


### PR DESCRIPTION
This PR introduces a new POST endpoint /api/expenses that allows for add new Trip records. The implementation includes both the service and controller layers necessary to support this functionality. Additionally, unit and integration tests have been added to ensure the endpoint behaves as expected.
