### PR TITLE
Backend/feature/delete trip

### DIFF
--- a/backend/src/main/java/org/example/backend/controller/TripController.java
+++ b/backend/src/main/java/org/example/backend/controller/TripController.java
@@ -24,4 +24,9 @@ public class TripController {
     public Trip postTrip(@RequestBody TripDto newTripEntries){
         return tripService.addTrip(newTripEntries);
     }
+
+    @DeleteMapping("{id}")
+    public String deleteTrip(@PathVariable String id){
+        return tripService.deleteTrip(id);
+    }
 }

--- a/backend/src/main/java/org/example/backend/exception/ErrorObject.java
+++ b/backend/src/main/java/org/example/backend/exception/ErrorObject.java
@@ -1,0 +1,4 @@
+package org.example.backend.exception;
+
+public record ErrorObject(String message) {
+}

--- a/backend/src/main/java/org/example/backend/exception/GlobalException.java
+++ b/backend/src/main/java/org/example/backend/exception/GlobalException.java
@@ -1,0 +1,16 @@
+package org.example.backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalException {
+
+    @ExceptionHandler(TripNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorObject handleTripNotFoundException(TripNotFoundException exception){
+        return new ErrorObject(exception.getMessage());
+    }
+}

--- a/backend/src/main/java/org/example/backend/exception/TripNotFoundException.java
+++ b/backend/src/main/java/org/example/backend/exception/TripNotFoundException.java
@@ -2,6 +2,6 @@ package org.example.backend.exception;
 
 public class TripNotFoundException extends RuntimeException{
     public TripNotFoundException(String id){
-        super("Expense not found with id: " + id);
+        super("Trip not found with id: " + id);
     }
 }

--- a/backend/src/main/java/org/example/backend/exception/TripNotFoundException.java
+++ b/backend/src/main/java/org/example/backend/exception/TripNotFoundException.java
@@ -1,0 +1,7 @@
+package org.example.backend.exception;
+
+public class TripNotFoundException extends RuntimeException{
+    public TripNotFoundException(String id){
+        super("Expense not found with id: " + id);
+    }
+}

--- a/backend/src/main/java/org/example/backend/service/TripService.java
+++ b/backend/src/main/java/org/example/backend/service/TripService.java
@@ -1,6 +1,7 @@
 package org.example.backend.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.backend.exception.TripNotFoundException;
 import org.example.backend.model.Trip;
 import org.example.backend.model.TripDto;
 import org.example.backend.repo.TripRepo;
@@ -28,5 +29,13 @@ public class TripService {
         );
 
           return tripRepo.save(newTrip);
+    }
+
+    public String deleteTrip(String id) {
+        if(!tripRepo.existsById(id)){
+            throw new TripNotFoundException(id);
+        }
+        tripRepo.deleteById(id);
+        return id;
     }
 }

--- a/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
@@ -103,5 +103,19 @@ class TripControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk());
     }
 
+    @Test
+    @DirtiesContext
+    void deleteNonExistentTrip() throws Exception {
+        String nonExistentTripId = "999";
+
+        mvc.perform(MockMvcRequestBuilders.delete("/api/trips/" + nonExistentTripId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "message": "Trip not found with id: 999"
+                        }
+                        """));
+    }
 
 }

--- a/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
@@ -1,13 +1,20 @@
 package org.example.backend.controller;
 
+import org.example.backend.model.Destination;
+import org.example.backend.model.Trip;
+import org.example.backend.repo.TripRepo;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -17,6 +24,8 @@ class TripControllerTest {
 
     @Autowired
     MockMvc mvc;
+    @Autowired
+    private TripRepo tripRepo;
 
     @Test
     void getAllTrips() throws Exception {
@@ -78,4 +87,21 @@ class TripControllerTest {
                 ))
                 .andExpect(jsonPath("$.id").exists());
     }
+
+    @Test
+    @DirtiesContext
+    void deleteTrip() throws Exception {
+
+        Destination destination1 = new Destination("Germany", "Berlin", "Berlin", LocalDateTime.now());
+
+        Trip trip1 = new Trip("1", "Business Trip", "Meeting with clients", "Business", List.of(destination1));
+
+        tripRepo.save(trip1);
+
+        mvc.perform(MockMvcRequestBuilders
+                        .delete("/api/trips/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+
 }

--- a/backend/src/test/java/org/example/backend/service/TripServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/TripServiceTest.java
@@ -60,4 +60,24 @@ class TripServiceTest {
 
 
     }
+
+    @Test
+    @DirtiesContext
+    void deleteTrip() {
+
+        Destination destination1 = new Destination("Germany", "Berlin", "Berlin", LocalDateTime.now());
+
+        Trip trip1 = new Trip("1", "Business Trip", "Meeting with clients", "Business", List.of(destination1));
+
+        when(tripRepoMock.existsById(trip1.id())).thenReturn(true);
+        doNothing().when(tripRepoMock).deleteById(trip1.id());
+
+        String result = tripService.deleteTrip("1");
+
+        verify(tripRepoMock).existsById(trip1.id());
+        verify(tripRepoMock).deleteById(trip1.id());
+
+        assertEquals(trip1.id(), result);
+
+    }
 }

--- a/backend/src/test/java/org/example/backend/service/TripServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/TripServiceTest.java
@@ -1,5 +1,6 @@
 package org.example.backend.service;
 
+import org.example.backend.exception.TripNotFoundException;
 import org.example.backend.model.Destination;
 import org.example.backend.model.Trip;
 import org.example.backend.model.TripDto;
@@ -63,7 +64,7 @@ class TripServiceTest {
 
     @Test
     @DirtiesContext
-    void deleteTrip() {
+    void deleteTrip_whenIdExists() {
 
         Destination destination1 = new Destination("Germany", "Berlin", "Berlin", LocalDateTime.now());
 
@@ -79,5 +80,21 @@ class TripServiceTest {
 
         assertEquals(trip1.id(), result);
 
+    }
+
+    @Test
+    @DirtiesContext
+    void deleteTrip_idNotFound() {
+
+
+        String nonExistentId = "999";
+
+        when(tripRepoMock.existsById(nonExistentId)).thenReturn(false);
+
+        assertThrows(TripNotFoundException.class, () -> {
+            tripService.deleteTrip(nonExistentId);
+        });
+
+        verify(tripRepoMock).existsById(nonExistentId);
     }
 }


### PR DESCRIPTION
This PR introduces a new DELETE endpoint /api/trip/{id} that allows for deleting a specific trip record. The implementation includes both the service and controller layers necessary to support this functionality. Additionally, unit and integration tests have been added to ensure the endpoint behaves as expected.
