### PR TITLE
Feature/backend/put trip

### DIFF
--- a/backend/src/main/java/org/example/backend/controller/TripController.java
+++ b/backend/src/main/java/org/example/backend/controller/TripController.java
@@ -25,6 +25,11 @@ public class TripController {
         return tripService.addTrip(newTripEntries);
     }
 
+    @PutMapping()
+    public Trip putTrip(@RequestBody Trip trip){
+        return tripService.updateTrip(trip);
+    }
+
     @DeleteMapping("{id}")
     public String deleteTrip(@PathVariable String id){
         return tripService.deleteTrip(id);

--- a/backend/src/main/java/org/example/backend/model/Trip.java
+++ b/backend/src/main/java/org/example/backend/model/Trip.java
@@ -1,9 +1,11 @@
 package org.example.backend.model;
 
+import lombok.With;
 import org.springframework.data.mongodb.core.mapping.MongoId;
 
 import java.util.List;
 
+@With
 public record Trip(
         @MongoId
         String id,

--- a/backend/src/main/java/org/example/backend/service/TripService.java
+++ b/backend/src/main/java/org/example/backend/service/TripService.java
@@ -38,4 +38,15 @@ public class TripService {
         tripRepo.deleteById(id);
         return id;
     }
+
+    public Trip updateTrip(Trip trip) {
+        Trip oldTrip = tripRepo.findById(trip.id()).orElseThrow(()-> new TripNotFoundException(trip.id()));
+        Trip updatedTrip = oldTrip
+                .withTitle(trip.title())
+                .withDescription(trip.description())
+                .withReason(trip.reason())
+                .withDestinations(trip.destinations());
+
+        return tripRepo.save(updatedTrip);
+    }
 }

--- a/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
+++ b/backend/src/test/java/org/example/backend/controller/TripControllerTest.java
@@ -118,4 +118,65 @@ class TripControllerTest {
                         """));
     }
 
+
+    @Test
+    @DirtiesContext
+    void putTrip() throws Exception {
+        Destination oldDestination = new Destination("Germany", "Berlin", "Berlin", LocalDateTime.now());
+        Trip oldTrip = new Trip("1", "Business Trip", "Meeting with clients", "Business", List.of(oldDestination));
+
+        tripRepo.save(oldTrip);
+
+        mvc.perform(MockMvcRequestBuilders
+                .put("/api/trips")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+{
+                                    "id": "1",
+                                    "title": "Business Trip",
+                                    "description": "Meeting with clients",
+                                    "reason": "Business",
+                                    "destinations": [
+                                        {
+                                            "country": "Germany",
+                                            "city": "Berlin",
+                                            "region": "Berlin",
+                                            "date": "2024-05-20T00:00:00"
+                                        },
+                                        {
+                                            "country": "France",
+                                            "city": "Paris",
+                                            "region": "Île-de-France",
+                                            "date": "2024-05-25T00:00:00"
+                                        }
+                                    ]
+                                }
+"""
+                ))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+{
+                                    "id": "1",
+                                    "title": "Business Trip",
+                                    "description": "Meeting with clients",
+                                    "reason": "Business",
+                                    "destinations": [
+                                        {
+                                            "country": "Germany",
+                                            "city": "Berlin",
+                                            "region": "Berlin",
+                                            "date": "2024-05-20T00:00:00"
+                                        },
+                                        {
+                                            "country": "France",
+                                            "city": "Paris",
+                                            "region": "Île-de-France",
+                                            "date": "2024-05-25T00:00:00"
+                                        }
+                                    ]
+                                }
+"""
+
+                ));
+    }
 }

--- a/backend/src/test/java/org/example/backend/service/TripServiceTest.java
+++ b/backend/src/test/java/org/example/backend/service/TripServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -97,4 +98,46 @@ class TripServiceTest {
 
         verify(tripRepoMock).existsById(nonExistentId);
     }
+
+
+    @Test
+    @DirtiesContext
+    void updateTrip_whenIdExists() {
+        Destination oldDestination = new Destination("Germany", "Berlin", "Berlin", LocalDateTime.now());
+        Destination updatedDestination = new Destination("Germany", "Hamburg", "Hamburg", LocalDateTime.now());
+
+        Trip oldTrip = new Trip("1", "Business Trip", "Meeting with clients", "Business", List.of(oldDestination));
+        Trip updatedTrip = new Trip("1", "Business Trip", "Meeting with CEO", "Business", List.of(updatedDestination));
+
+        when(tripRepoMock.findById("1")).thenReturn(Optional.of(oldTrip));
+        when(tripRepoMock.save(updatedTrip)).thenReturn(updatedTrip);
+
+        Trip result = tripService.updateTrip(updatedTrip);
+
+        assertEquals(updatedTrip, result);
+
+        verify(tripRepoMock).findById("1");
+        verify(tripRepoMock).save(updatedTrip);
+
+    }
+
+    @Test
+    @DirtiesContext
+    void updateTrip_idNotFound() {
+
+        String nonExistentId = "999";
+
+        Destination updatedDestination = new Destination("Germany", "Hamburg", "Hamburg", LocalDateTime.now());
+
+        Trip updatedTrip = new Trip(nonExistentId, "Business Trip", "Meeting with CEO", "Business", List.of(updatedDestination));
+
+        when(tripRepoMock.findById(nonExistentId)).thenThrow(new TripNotFoundException(nonExistentId));
+
+        assertThrows(TripNotFoundException.class, () -> {
+            tripService.updateTrip(updatedTrip);
+        });
+
+        verify(tripRepoMock).findById(nonExistentId);
+    }
+
 }


### PR DESCRIPTION
This PR introduces a new POST endpoint /api/trips that allows for updating a specific Trip record. The implementation includes both the service and controller layers necessary to support this functionality. Additionally, unit and integration tests have been added to ensure the endpoint behaves as expected.
